### PR TITLE
Add fix for generating embeddings

### DIFF
--- a/src/trowel/cli.py
+++ b/src/trowel/cli.py
@@ -340,6 +340,7 @@ def generate_embeddings(input_file, collection, db_path, text_fields, limit, ski
                     db_path,
                     collection,
                     export_csv,
+                    include_embeddings=True,
                 )
                 logging.info(f"Exported {num_exported} embeddings to {export_csv}")
                 logging.info("You can now use these embeddings with other embedding commands:")

--- a/src/trowel/utils/embedding_generation_utils.py
+++ b/src/trowel/utils/embedding_generation_utils.py
@@ -212,7 +212,11 @@ def export_embeddings_to_csv(
         # Get field names for the collection. Some CurateGPT backends can return
         # empty field_names even when rows exist, so fall back to inferring them.
         field_names = store.field_names(collection=collection_name) or []
-        raw_results = list(store.find(where={}, collection=collection_name))
+        find_kwargs = {"where": {}, "collection": collection_name}
+        if include_embeddings:
+            find_kwargs["include"] = ["metadatas", "documents", "embeddings"]
+
+        raw_results = list(store.find(**find_kwargs))
         docs = []
         for result in raw_results:
             normalized = _normalize_store_result(

--- a/tests/test_cli_embeddings.py
+++ b/tests/test_cli_embeddings.py
@@ -132,7 +132,12 @@ class TestGenerateEmbeddingsCommand:
             assert result.exit_code == 0
             assert "Exporting embeddings to" in result.output
             assert "Exported 3 embeddings" in result.output
-            assert mock_export.called
+            mock_export.assert_called_once_with(
+                db_path,
+                "embeddings",
+                export_path,
+                include_embeddings=True,
+            )
 
     @patch("trowel.cli.generate_embeddings_with_curategpt")
     def test_command_with_limit(self, mock_generate, runner, sample_csv, temp_dir):

--- a/tests/test_embedding_generation.py
+++ b/tests/test_embedding_generation.py
@@ -422,3 +422,49 @@ class TestExportEmbeddingsToCSV:
             rows = list(reader)
             assert len(rows) == 2
             assert rows[0]["id"] == "BERVO:0000001"
+
+    @patch("trowel.utils.embedding_generation_utils._get_curategpt_store")
+    def test_csv_export_requests_duckdb_embeddings_when_included(
+        self,
+        mock_get_store,
+        temp_dir,
+    ):
+        """Test export requests embeddings when requested."""
+        db_path = os.path.join(temp_dir, "test.duckdb")
+        os.makedirs(db_path, exist_ok=True)
+
+        mock_store = MagicMock()
+        mock_get_store.return_value = mock_store
+        mock_store.field_names.return_value = []
+
+        def fake_find(where, collection, include=None):
+            embeddings = (
+                [0.1, 0.2]
+                if include and "embeddings" in include
+                else None
+            )
+            return [
+                (
+                    {"id": "BERVO:0000001", "label": "Temperature"},
+                    0.0,
+                    {"_embeddings": embeddings, "documents": "Temperature"},
+                )
+            ]
+
+        mock_store.find.side_effect = fake_find
+
+        output_path = os.path.join(temp_dir, "output.csv")
+        num_exported = export_embeddings_to_csv(
+            db_path,
+            "test_collection",
+            output_path,
+            include_embeddings=True,
+        )
+
+        assert num_exported == 1
+        with open(output_path, 'r') as f:
+            reader = csv.DictReader(f)
+            rows = list(reader)
+            assert len(rows) == 1
+            assert "embeddings" in reader.fieldnames
+            assert rows[0]["embeddings"] == "[0.1, 0.2]"


### PR DESCRIPTION
This pull request enhances the embedding export functionality by ensuring that embeddings are correctly included in CSV exports when requested, and adds comprehensive test coverage for this behavior. The changes also improve the reliability of the export process and update related tests to check for the correct function calls and output.

**Embedding Export Improvements:**

* The `export_embeddings_to_csv` function in `embedding_generation_utils.py` now includes embeddings in the export when `include_embeddings=True` is specified, by passing the appropriate argument to the store's `find` method.
* The CLI's `generate_embeddings` function now always sets `include_embeddings=True` when exporting embeddings, ensuring that the exported CSV contains embedding data.

**Testing Enhancements:**

* The test for CLI embedding export in `test_cli_embeddings.py` now asserts that `export_embeddings_to_csv` is called with `include_embeddings=True`, verifying the correct function call signature.
* A new test in `test_embedding_generation.py` verifies that embeddings are included in the CSV output when requested, and that the output has the expected format and content.