### PR TITLE
Add model parameter for generating embeddings

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,14 +174,14 @@ trowel embeddings prepare-embeddings \
 
 #### generate-embeddings
 
-Generate vector embeddings for CSV data using CurateGPT and OpenAI's embedding API.
+Generate vector embeddings for CSV data using CurateGPT.
 
-This command handles the complete embedding pipeline: reading your prepared data, calling OpenAI's `text-embedding-ada-002` model for each row, storing embeddings in a DuckDB database, and optionally exporting results to CSV for downstream analysis.
+This command handles the complete embedding pipeline: reading your prepared data, calling CurateGPT's embedding model for each row, storing embeddings in a DuckDB database, and optionally exporting results to CSV for downstream analysis.
 
 **Requirements:**
-- `OPENAI_API_KEY` environment variable must be set
 - CurateGPT installed: `pip install curategpt`
 - DuckDB installed: `pip install duckdb`
+- `OPENAI_API_KEY` environment variable must be set only when using an OpenAI model
 
 ```bash
 # Basic usage - embed a prepared file
@@ -203,6 +203,11 @@ trowel embeddings generate-embeddings \
   -i bervo_prepared.csv \
   -f "id,label,definition"
 
+# Specify a CurateGPT embedding model
+trowel embeddings generate-embeddings \
+  -i bervo_prepared.csv \
+  -m openai:text-embedding-3-small
+
 # Generate and export embeddings for use with other commands
 trowel embeddings generate-embeddings \
   -i bervo_prepared.csv \
@@ -217,13 +222,14 @@ trowel embeddings generate-embeddings \
 - `-l, --limit INTEGER` - Maximum rows to embed (useful for testing large files)
 - `-s, --skip INTEGER` - Number of rows to skip from beginning
 - `-e, --export TEXT` - Optional: export embeddings to CSV file after generation
+- `-m, --model TEXT` - CurateGPT embedding model. Use CurateGPT's `openai:<model-name>` syntax for OpenAI models
 
 **Output:**
 - DuckDB database stored at `--db-path` location (default: `./backup/db.duckdb`)
 - If `--export` specified: CSV file with embeddings for use with other commands
 
 **Note on Costs:**
-Each embedding call uses OpenAI's API and incurs a small cost. The `text-embedding-ada-002` model is one of the most affordable OpenAI models. For BERVO (5000+ terms), expect costs of a few dollars.
+OpenAI embedding models incur API costs. CurateGPT's default Hugging Face/SentenceTransformer model does not use OpenAI billing.
 
 #### load-embeddings
 

--- a/src/trowel/cli.py
+++ b/src/trowel/cli.py
@@ -269,17 +269,18 @@ def prepare_embeddings(input_file, output_file, columns, skip_rows):
 @click.option('-l', '--limit', type=int, default=None, help='Maximum number of rows to embed (for testing/sampling).')
 @click.option('-s', '--skip', type=int, default=0, help='Number of rows to skip from the beginning.')
 @click.option('-e', '--export', 'export_csv', help='Optional: export embeddings to CSV file after generation.', required=False)
-def generate_embeddings(input_file, collection, db_path, text_fields, limit, skip, export_csv):
-    """Generate embeddings for CSV data using CurateGPT with OpenAI API.
+@click.option('-m', '--model', help='CurateGPT embedding model. Use "openai:<model-name>" for OpenAI models.', required=False)
+def generate_embeddings(input_file, collection, db_path, text_fields, limit, skip, export_csv, model):
+    """Generate embeddings for CSV data using CurateGPT.
 
     This command:
     1. Reads a prepared CSV file
-    2. Generates vector embeddings using OpenAI's text-embedding-ada-002 model
+    2. Generates vector embeddings using CurateGPT
     3. Stores embeddings in a DuckDB database
     4. Optionally exports results to CSV for downstream analysis
 
     REQUIREMENTS:
-    - OPENAI_API_KEY environment variable must be set
+    - OPENAI_API_KEY environment variable must be set for OpenAI models
     - Install CurateGPT: pip install curategpt
     - Install DuckDB: pip install duckdb
 
@@ -296,6 +297,9 @@ def generate_embeddings(input_file, collection, db_path, text_fields, limit, ski
         # Specify which columns to use for embeddings
         trowel embeddings generate-embeddings -i bervo_prepared.csv -f "id,label,definition"
 
+        # Specify a CurateGPT embedding model
+        trowel embeddings generate-embeddings -i bervo_prepared.csv -m openai:text-embedding-3-small
+
         # Export to CSV for use with other commands
         trowel embeddings generate-embeddings -i bervo_prepared.csv -e backup/bervo_embeds.csv
     """
@@ -303,11 +307,10 @@ def generate_embeddings(input_file, collection, db_path, text_fields, limit, ski
         logging.error(f"Input file {input_file} does not exist.")
         sys.exit(1)
 
-    # Check for OpenAI API key
-    if not os.getenv("OPENAI_API_KEY"):
+    if model and model.startswith("openai:") and not os.getenv("OPENAI_API_KEY"):
         logging.error(
             "OPENAI_API_KEY environment variable is not set. "
-            "CurateGPT requires an OpenAI API key for embedding generation. "
+            "CurateGPT requires an OpenAI API key for OpenAI embeddings. "
             "Set it with: export OPENAI_API_KEY='your-key-here'"
         )
         sys.exit(1)
@@ -327,6 +330,7 @@ def generate_embeddings(input_file, collection, db_path, text_fields, limit, ski
             text_fields=text_fields_list,
             limit=limit,
             skip=skip,
+            model=model,
         )
 
         logging.info(f"Successfully generated {num_embeddings} embeddings")

--- a/src/trowel/utils/embedding_generation_utils.py
+++ b/src/trowel/utils/embedding_generation_utils.py
@@ -53,11 +53,12 @@ def generate_embeddings_with_curategpt(
     text_fields: Optional[List[str]] = None,
     limit: Optional[int] = None,
     skip: int = 0,
+    model: Optional[str] = None,
 ) -> Tuple[str, int]:
     """Generate embeddings for CSV data using CurateGPT with DuckDB backend.
 
     Initializes a CurateGPT store with DuckDB backend and generates
-    vector embeddings for each row using OpenAI's text-embedding-ada-002 model.
+    vector embeddings for each row using CurateGPT's configured model.
 
     Args:
         csv_path: Path to the CSV file containing data to embed
@@ -67,22 +68,24 @@ def generate_embeddings_with_curategpt(
                     If None, uses all columns concatenated.
         limit: Maximum number of rows to embed (for testing/sampling)
         skip: Number of rows to skip from the beginning
+        model: CurateGPT embedding model string. For OpenAI models, use
+               CurateGPT's "openai:<model-name>" syntax.
 
     Returns:
         Tuple of (database_path, number_of_embeddings_created)
 
     Raises:
         FileNotFoundError: If the CSV file does not exist
-        ImportError: If curategpt or duckdb is not installed or OPENAI_API_KEY is not set
+        ImportError: If curategpt or duckdb is not installed or an OpenAI
+                     model is requested without OPENAI_API_KEY
     """
     if not os.path.exists(csv_path):
         raise FileNotFoundError(f"CSV file not found: {csv_path}")
 
-    # Check for OpenAI API key
-    if not os.getenv("OPENAI_API_KEY"):
+    if model and model.startswith("openai:") and not os.getenv("OPENAI_API_KEY"):
         raise ImportError(
             "OPENAI_API_KEY environment variable is not set. "
-            "CurateGPT requires an OpenAI API key for embedding generation. "
+            "CurateGPT requires an OpenAI API key for OpenAI embeddings. "
             "Set it with: export OPENAI_API_KEY='your-key-here'"
         )
 
@@ -107,6 +110,8 @@ def generate_embeddings_with_curategpt(
     os.makedirs(db_dir, exist_ok=True)
 
     logging.info(f"Initializing CurateGPT store with DuckDB at {db_path}...")
+    if model:
+        logging.info(f"Using CurateGPT embedding model: {model}")
 
     logging.info(f"Loading data from {csv_path}...")
     rows_read = 0
@@ -145,7 +150,10 @@ def generate_embeddings_with_curategpt(
                 try:
                     # Insert the row with its text content
                     # CurateGPT will automatically generate embeddings
-                    store.insert([row], collection=collection_name)
+                    insert_kwargs = {"collection": collection_name}
+                    if model:
+                        insert_kwargs["model"] = model
+                    store.insert([row], **insert_kwargs)
                     rows_inserted += 1
 
                     if rows_inserted % 100 == 0:

--- a/tests/test_cli_embeddings.py
+++ b/tests/test_cli_embeddings.py
@@ -63,14 +63,20 @@ class TestGenerateEmbeddingsCommand:
         assert result.exit_code != 0
         assert "does not exist" in result.output
 
-    def test_command_requires_openai_api_key(self, runner, sample_csv, temp_dir):
-        """Test that command fails without OPENAI_API_KEY."""
+    def test_command_requires_openai_api_key_for_openai_model(
+        self,
+        runner,
+        sample_csv,
+        temp_dir,
+    ):
+        """Test that command fails without OPENAI_API_KEY for OpenAI models."""
         # Clear environment
         with patch.dict(os.environ, {}, clear=True):
             result = runner.invoke(main, [
                 "embeddings", "generate-embeddings",
                 "-i", sample_csv,
-                "-d", os.path.join(temp_dir, "test.duckdb")
+                "-d", os.path.join(temp_dir, "test.duckdb"),
+                "-m", "openai:text-embedding-3-small",
             ])
             assert result.exit_code != 0
             assert "OPENAI_API_KEY" in result.output
@@ -195,6 +201,50 @@ class TestGenerateEmbeddingsCommand:
             mock_generate.assert_called_once()
             call_kwargs = mock_generate.call_args[1]
             assert call_kwargs["text_fields"] == ["label", "definition"]
+
+    @patch("trowel.cli.generate_embeddings_with_curategpt")
+    def test_command_with_model(self, mock_generate, runner, sample_csv, temp_dir):
+        """Test command with CurateGPT model parameter."""
+        db_path = os.path.join(temp_dir, "test.duckdb")
+        mock_generate.return_value = (db_path, 3)
+
+        with patch.dict(os.environ, {}, clear=True):
+            result = runner.invoke(main, [
+                "embeddings", "generate-embeddings",
+                "-i", sample_csv,
+                "-d", db_path,
+                "-m", "all-MiniLM-L6-v2",
+            ])
+
+            assert result.exit_code == 0
+            mock_generate.assert_called_once()
+            call_kwargs = mock_generate.call_args[1]
+            assert call_kwargs["model"] == "all-MiniLM-L6-v2"
+
+    @patch("trowel.cli.generate_embeddings_with_curategpt")
+    def test_command_with_openai_model_and_api_key(
+        self,
+        mock_generate,
+        runner,
+        sample_csv,
+        temp_dir,
+    ):
+        """Test command forwards OpenAI model when OPENAI_API_KEY is set."""
+        db_path = os.path.join(temp_dir, "test.duckdb")
+        mock_generate.return_value = (db_path, 3)
+
+        with patch.dict(os.environ, {"OPENAI_API_KEY": "test-key"}):
+            result = runner.invoke(main, [
+                "embeddings", "generate-embeddings",
+                "-i", sample_csv,
+                "-d", db_path,
+                "-m", "openai:text-embedding-3-small",
+            ])
+
+            assert result.exit_code == 0
+            mock_generate.assert_called_once()
+            call_kwargs = mock_generate.call_args[1]
+            assert call_kwargs["model"] == "openai:text-embedding-3-small"
 
     @patch("trowel.cli.export_embeddings_to_csv")
     @patch("trowel.cli.generate_embeddings_with_curategpt")

--- a/tests/test_embedding_generation.py
+++ b/tests/test_embedding_generation.py
@@ -71,13 +71,14 @@ class TestGenerateEmbeddingsWithCurategpt:
                 db_path=os.path.join(temp_dir, "test.duckdb")
             )
 
-    def test_missing_openai_api_key(self, sample_csv, temp_dir):
-        """Test that function raises error when OPENAI_API_KEY is not set."""
+    def test_missing_openai_api_key_for_openai_model(self, sample_csv, temp_dir):
+        """Test that OpenAI models require OPENAI_API_KEY."""
         with patch.dict(os.environ, {}, clear=True):
             with pytest.raises(ImportError, match="OPENAI_API_KEY"):
                 generate_embeddings_with_curategpt(
                     sample_csv,
-                    db_path=os.path.join(temp_dir, "test.duckdb")
+                    db_path=os.path.join(temp_dir, "test.duckdb"),
+                    model="openai:text-embedding-3-small",
                 )
 
     def test_missing_curategpt(self, sample_csv, temp_dir):
@@ -199,6 +200,46 @@ class TestGenerateEmbeddingsWithCurategpt:
             # Assertions
             assert num_embeddings == 3
             assert mock_store.insert.call_count == 3
+
+    @patch("trowel.utils.embedding_generation_utils._get_curategpt_store")
+    def test_embedding_with_model(self, mock_get_store, sample_csv, temp_dir):
+        """Test that model parameter is passed to CurateGPT insert."""
+        mock_store = MagicMock()
+        mock_get_store.return_value = mock_store
+
+        with patch.dict(os.environ, {}, clear=True):
+            db_path = os.path.join(temp_dir, "test.duckdb")
+
+            result_path, num_embeddings = generate_embeddings_with_curategpt(
+                sample_csv,
+                db_path=db_path,
+                model="all-MiniLM-L6-v2",
+            )
+
+            assert result_path == db_path
+            assert num_embeddings == 3
+            first_insert_kwargs = mock_store.insert.call_args_list[0][1]
+            assert first_insert_kwargs["model"] == "all-MiniLM-L6-v2"
+
+    @patch("trowel.utils.embedding_generation_utils._get_curategpt_store")
+    def test_embedding_without_model_uses_curategpt_default(
+        self,
+        mock_get_store,
+        sample_csv,
+        temp_dir,
+    ):
+        """Test that model is omitted when caller uses the CurateGPT default."""
+        mock_store = MagicMock()
+        mock_get_store.return_value = mock_store
+
+        with patch.dict(os.environ, {}, clear=True):
+            generate_embeddings_with_curategpt(
+                sample_csv,
+                db_path=os.path.join(temp_dir, "test.duckdb"),
+            )
+
+            first_insert_kwargs = mock_store.insert.call_args_list[0][1]
+            assert "model" not in first_insert_kwargs
 
     @patch("trowel.utils.embedding_generation_utils._get_curategpt_store")
     def test_database_directory_creation(self, mock_get_store, sample_csv, temp_dir):


### PR DESCRIPTION
This pull request updates the embeddings generation pipeline to support selecting any CurateGPT embedding model, including OpenAI and Hugging Face models, via a new `--model` parameter. The changes clarify when the `OPENAI_API_KEY` is required, improve help/documentation, and add comprehensive tests for the new behavior.

**Major CLI and API improvements:**

* Added a `--model` (`-m`) option to the `generate-embeddings` command, allowing users to specify the CurateGPT embedding model (e.g., `openai:text-embedding-3-small` or a Hugging Face model). The code now only requires `OPENAI_API_KEY` if an OpenAI model is selected, and passes the model parameter through all layers to CurateGPT. [[1]](diffhunk://#diff-ad9e3e26a4d3127d5f02d71314c3cf3cfbb5bb66a02f229d2414bf58928ebbb7L272-R283) [[2]](diffhunk://#diff-ad9e3e26a4d3127d5f02d71314c3cf3cfbb5bb66a02f229d2414bf58928ebbb7R300-R313) [[3]](diffhunk://#diff-ad9e3e26a4d3127d5f02d71314c3cf3cfbb5bb66a02f229d2414bf58928ebbb7R333) [[4]](diffhunk://#diff-bed89b643a2118f4e285e74598fcb0c3470cbb56b1f0eb6ca5c18bec2c29930bR56-R61) [[5]](diffhunk://#diff-bed89b643a2118f4e285e74598fcb0c3470cbb56b1f0eb6ca5c18bec2c29930bR71-R88) [[6]](diffhunk://#diff-bed89b643a2118f4e285e74598fcb0c3470cbb56b1f0eb6ca5c18bec2c29930bR113-R114) [[7]](diffhunk://#diff-bed89b643a2118f4e285e74598fcb0c3470cbb56b1f0eb6ca5c18bec2c29930bL148-R156)

**Documentation updates:**

* Updated the `README.md` to reflect the new model selection option, clarify requirements for `OPENAI_API_KEY`, and improve cost explanations. Added usage examples for specifying a model. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L177-R184) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R206-R210) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R225-R232)

**Testing improvements:**

* Added and updated tests to verify that:
    - The CLI only requires `OPENAI_API_KEY` for OpenAI models.
    - The model parameter is passed to CurateGPT.
    - The default behavior is preserved if no model is specified.
    - The error handling and help messages are correct for all scenarios. [[1]](diffhunk://#diff-3c520dfe19e6026afe5815bf7b0976180eb797099b1afb555c62c66d9b046cabL66-R79) [[2]](diffhunk://#diff-3c520dfe19e6026afe5815bf7b0976180eb797099b1afb555c62c66d9b046cabR205-R248) [[3]](diffhunk://#diff-093d63704bd3d51cd9706df8d49a768f81da6a78f8a22973f7cdd02005689a1fL74-R81) [[4]](diffhunk://#diff-093d63704bd3d51cd9706df8d49a768f81da6a78f8a22973f7cdd02005689a1fR204-R243)

These changes make the embeddings pipeline more flexible, user-friendly, and robust for both OpenAI and non-OpenAI embedding models.